### PR TITLE
Reload only configured objects

### DIFF
--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -124,8 +124,8 @@ func main() {
 func RefreshDepartureLoop(manager *forseti.DataManager,
 	departuresURI url.URL,
 	departuresRefresh, connectionTimeout time.Duration) {
-	if departuresRefresh.Seconds() < 1 {
-		logrus.Info("data refreshing is disabled")
+	if (len(departuresURI.String()) == 0 || departuresRefresh.Seconds() < 1) {
+		logrus.Debug("Departure data refreshing is disabled")
 		return
 	}
 	for {
@@ -141,6 +141,10 @@ func RefreshDepartureLoop(manager *forseti.DataManager,
 func RefreshParkingLoop(manager *forseti.DataManager,
 	parkingsURI url.URL,
 	parkingsRefresh, connectionTimeout time.Duration) {
+	if (len(parkingsURI.String()) == 0 || parkingsRefresh.Seconds() < 1){
+		logrus.Debug("Parking data refreshing is disabled")
+		return
+	}
 	for {
 		err := forseti.RefreshParkings(manager, parkingsURI, connectionTimeout)
 		if err != nil {
@@ -154,6 +158,10 @@ func RefreshParkingLoop(manager *forseti.DataManager,
 func RefreshEquipmentLoop(manager *forseti.DataManager,
 	equipmentsURI url.URL,
 	equipmentsRefresh, connectionTimeout time.Duration) {
+	if (len(equipmentsURI.String()) == 0 || equipmentsRefresh.Seconds() < 1){
+		logrus.Debug("Equipment data refreshing is disabled")
+		return
+	}
 	for {
 		err := forseti.RefreshEquipments(manager, equipmentsURI, connectionTimeout)
 		if err != nil {

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -124,7 +124,7 @@ func main() {
 func RefreshDepartureLoop(manager *forseti.DataManager,
 	departuresURI url.URL,
 	departuresRefresh, connectionTimeout time.Duration) {
-	if (len(departuresURI.String()) == 0 || departuresRefresh.Seconds() < 1) {
+	if (len(departuresURI.String()) == 0 || departuresRefresh.Seconds() <= 0) {
 		logrus.Debug("Departure data refreshing is disabled")
 		return
 	}
@@ -141,7 +141,7 @@ func RefreshDepartureLoop(manager *forseti.DataManager,
 func RefreshParkingLoop(manager *forseti.DataManager,
 	parkingsURI url.URL,
 	parkingsRefresh, connectionTimeout time.Duration) {
-	if (len(parkingsURI.String()) == 0 || parkingsRefresh.Seconds() < 1){
+	if (len(parkingsURI.String()) == 0 || parkingsRefresh.Seconds() <= 0){
 		logrus.Debug("Parking data refreshing is disabled")
 		return
 	}
@@ -158,7 +158,7 @@ func RefreshParkingLoop(manager *forseti.DataManager,
 func RefreshEquipmentLoop(manager *forseti.DataManager,
 	equipmentsURI url.URL,
 	equipmentsRefresh, connectionTimeout time.Duration) {
-	if (len(equipmentsURI.String()) == 0 || equipmentsRefresh.Seconds() < 1){
+	if (len(equipmentsURI.String()) == 0 || equipmentsRefresh.Seconds() <= 0){
 		logrus.Debug("Equipment data refreshing is disabled")
 		return
 	}


### PR DESCRIPTION
Only objects configured or with parameters should be reloaded. 
For example, 
`
./forseti --equipments-uri file:///home/user/dev/forseti/fixtures/NET_ACCESS.XML --equipments-refresh=1s
`
should not try to reload other components like **parkings** and **equipments**

Concerned ticket: https://jira.kisio.org/browse/NAVP-1644