### PR TITLE
On/Off loading flucteo data by parameter and api

### DIFF
--- a/api.go
+++ b/api.go
@@ -138,6 +138,14 @@ func StatusHandler(manager *DataManager) gin.HandlerFunc {
 			toActive, _ := strconv.ParseBool(freeFloatingStatus)
 			manager.ManageFreeFloatingStatus(toActive)
 		}
+
+		// manage vehicleoccupancy activation /status?vehicle_occupancies=true or false
+		vehicleOccupancyStatus := c.Query("vehicle_occupancies")
+		if len(vehicleOccupancyStatus) > 0 {
+			toActive, _ := strconv.ParseBool(vehicleOccupancyStatus)
+			manager.ManageVehicleOccupancyStatus(toActive)
+		}
+
 		c.JSON(http.StatusOK, StatusResponse{
 			"ok",
 			ForsetiVersion,

--- a/api.go
+++ b/api.go
@@ -21,15 +21,20 @@ type DeparturesResponse struct {
 	Departures *[]Departure `json:"departures,omitempty"` // the pointer allow us to display an empty array in json
 }
 
+type LoadingStatus struct {
+	RefreshActive bool      `json:"refresh_active"`
+	LastUpdate    time.Time `json:"last_update"`
+}
+
 // StatusResponse defines the object returned by the /status endpoint
 type StatusResponse struct {
-	Status                     string    `json:"status,omitempty"`
-	Version                    string    `json:"version,omitempty"`
-	LastDepartureUpdate        time.Time `json:"last_departure_update"`
-	LastParkingUpdate          time.Time `json:"last_parking_update"`
-	LastEquipmentUpdate        time.Time `json:"last_equipment_update"`
-	LastFreeFloatingUpdate     time.Time `json:"last_free_floating_update"`
-	LastVehicleOccupancyUpdate time.Time `json:"last_vehicle_occupancy_update"`
+	Status              string        `json:"status,omitempty"`
+	Version             string        `json:"version,omitempty"`
+	LastDepartureUpdate time.Time     `json:"last_departure_update"`
+	LastParkingUpdate   time.Time     `json:"last_parking_update"`
+	LastEquipmentUpdate time.Time     `json:"last_equipment_update"`
+	FreeFloatings       LoadingStatus `json:"free_floatings,omitempty"`
+	VehicleOccupancies  LoadingStatus `json:"vehicle_occupancies,omitempty"`
 }
 
 // ParkingResponse defines how a parking object is represent in a response
@@ -152,8 +157,8 @@ func StatusHandler(manager *DataManager) gin.HandlerFunc {
 			manager.GetLastDepartureDataUpdate(),
 			manager.GetLastParkingsDataUpdate(),
 			manager.GetLastEquipmentsDataUpdate(),
-			manager.GetLastFreeFloatingsDataUpdate(),
-			manager.GetLastVehicleOccupanciesDataUpdate(),
+			LoadingStatus{manager.LoadFreeFloatingData(), manager.GetLastFreeFloatingsDataUpdate()},
+			LoadingStatus{manager.LoadOccupancyData(), manager.GetLastVehicleOccupanciesDataUpdate()},
 		})
 	}
 }

--- a/api.go
+++ b/api.go
@@ -132,6 +132,12 @@ func DeparturesHandler(manager *DataManager) gin.HandlerFunc {
 
 func StatusHandler(manager *DataManager) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// manage freefloating activation /status?free_floatings=true or false
+		freeFloatingStatus := c.Query("free_floatings")
+		if len(freeFloatingStatus) > 0 {
+			toActive, _ := strconv.ParseBool(freeFloatingStatus)
+			manager.ManageFreeFloatingStatus(toActive)
+		}
 		c.JSON(http.StatusOK, StatusResponse{
 			"ok",
 			ForsetiVersion,

--- a/cmd/forseti/main.go
+++ b/cmd/forseti/main.go
@@ -47,7 +47,7 @@ type Config struct {
 	LogLevel            string        `mapstructure:"log-level"`
 	ConnectionTimeout   time.Duration `mapstructure:"connection-timeout"`
 	JSONLog             bool          `mapstructure:"json-log"`
-	FreeFloatingsActive bool          `mapstructure:"free-floatings-active"`
+	FreeFloatingsActive bool          `mapstructure:"free-floatings-refresh-active"`
 }
 
 func noneOf(args ...string) bool {
@@ -71,7 +71,7 @@ func GetConfig() (Config, error) {
 	pflag.Duration("equipments-refresh", 30*time.Second, "time between refresh of equipments data")
 	pflag.String("free-floatings-uri", "", "format: [scheme:][//[userinfo@]host][/]path")
 	pflag.String("free-floatings-token", "", "token for free floating source")
-	pflag.Bool("free-floatings-active", true, "activation of vehicles in Fluctéo data")
+	pflag.Bool("free-floatings-refresh-active", false, "activate the periodic refresh of Fluctuo data")
 	pflag.Duration("free-floatings-refresh", 30*time.Second, "time between refresh of vehicles in Fluctéo data")
 
 	//Passing configurations for vehicle_occupancies
@@ -137,7 +137,7 @@ func main() {
 	location, _ := time.LoadLocation(config.TimeZoneLocation)
 
 	// Manage activation of vehicles in Fluctéo data
-	go ManagefreeFloatingActivation(manager, config.FreeFloatingsActive)
+	ManagefreeFloatingActivation(manager, config.FreeFloatingsActive)
 
 	err = forseti.RefreshDepartures(manager, config.DeparturesURI, config.ConnectionTimeout)
 	if err != nil {

--- a/loader.go
+++ b/loader.go
@@ -385,6 +385,10 @@ func LoadFreeFloatingData(data *Data) ([]FreeFloating, error) {
 }
 
 func RefreshFreeFloatings(manager *DataManager, uri url.URL, token string, connectionTimeout time.Duration) error {
+	// Continue using last loaded data if loading is deactivated
+	if !manager.LoadFreeFloatingData() {
+		return nil
+	}
 	begin := time.Now()
 	resp, err := CallHttpClient(uri.String(), token)
 

--- a/loader.go
+++ b/loader.go
@@ -657,6 +657,10 @@ func CreateOccupanciesFromPredictions(manager *DataManager, predictions []Predic
 
 func RefreshVehicleOccupancies(manager *DataManager, predict_url url.URL, predict_token string,
 	connectionTimeout time.Duration, location *time.Location) error {
+	// Continue using last loaded data if loading is deactivated
+	if !manager.LoadOccupancyData() {
+		return nil
+	}
 	begin := time.Now()
 	predictions, _ := LoadPredictions(predict_url, predict_token, connectionTimeout, location)
 	occupanciesWithCharge := CreateOccupanciesFromPredictions(manager, predictions)

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,19 @@ Run
 ===
 Once you have build it it's fairly easy to run it:
 ```
-./forseti --departures-uri file:///PATHTO/extract_edylic.txt --departures-refresh=1s --parkings-uri file:///PATH_TO/parkings.txt --parkings-refresh=2s --equipments-uri file:///home/kadhikari/dev/forseti/fixtures/NET_ACCESS.XML --equipments-refresh=2s --free-floatings-uri <freefloating source url> --free-floatings-token <token> --free-floatings-refresh=60s
+./forseti --departures-uri file:///PATHTO/extract_edylic.txt --departures-refresh=1s --parkings-uri file:///PATH_TO/parkings.txt --parkings-refresh=2s --equipments-uri file:///<PATH>/NET_ACCESS.XML --equipments-refresh=2s --free-floatings-uri <freefloating source url> --free-floatings-token <token> --free-floatings-refresh=60s free-floatings-refresh-active true
+
+```
+
+You can also run only one service for an instance (for example /vehicle_occupancies):
+```
+./forseti --occupancy-files-uri file:///<PATHTO> --occupancy-refresh=300s --occupancy-navitia-uri https://api.navitia.io/v1/coverage/fr-idf --occupancy-navitia-token <token navitia> --occupancy-service-uri <prediction service url> --occupancy-service-token <token clientapi>  --occupancy-service-refresh-active true
+
+```
+
+Or only /free_floatings
+```
+./forseti --free-floatings-uri <freefloating source url> --free-floatings-token <token clientapi> --free-floatings-refresh=10s --free-floatings-refresh-active true
 
 ```
 
@@ -44,9 +56,17 @@ Two routes are provided:
   - `/parkings/P+R` returns real time parkings data. (with an optional list parameter of `ids[]`)
   - `/equipments` returns informations on Equipments in StopAreas.
   - `/free_floatings?coord=2.37715%3B48.846781` returns informations on freefloatings  within a certain radius as a crow flies from the point.
+  - `/vehicle_occupancies` returns occupany of a vehicles at a stop.
+
 One goroutine is handling the refresh of the data by downloading them every refresh-interval (default: 30s)
 and load them. Once these data have been loaded there is swap of pointer being done so that every new requests
 will get the new dataset.
+
+It is also possible to activate/deactivate the periodic refresh of data for api /free_floatings and /vehicle_occupancies as shown below:
+  - `/status?free_floatings=false` desactive the periodic refresh of data for api /free_floatings.
+  - `/status?vehicle_occupancies=false` desactive the periodic refresh of data for api /vehicle_occupancies.
+
+After the deactivation the service keeps working with the last loaded data.
 
 General Architecture
 ================

--- a/readme.md
+++ b/readme.md
@@ -63,8 +63,8 @@ and load them. Once these data have been loaded there is swap of pointer being d
 will get the new dataset.
 
 It is also possible to activate/deactivate the periodic refresh of data for api /free_floatings and /vehicle_occupancies as shown below:
-  - `/status?free_floatings=false` desactive the periodic refresh of data for api /free_floatings.
-  - `/status?vehicle_occupancies=false` desactive the periodic refresh of data for api /vehicle_occupancies.
+  - `/status?free_floatings=false` deactivates the periodic refresh of data for api /free_floatings.
+  - `/status?vehicle_occupancies=false` deactivates the periodic refresh of data for api /vehicle_occupancies.
 
 After the deactivation the service keeps working with the last loaded data.
 

--- a/type.go
+++ b/type.go
@@ -607,6 +607,7 @@ type DataManager struct {
 	freeFloatings          *[]FreeFloating
 	lastFreeFloatingUpdate time.Time
 	freeFloatingsMutex     sync.RWMutex
+	loadFreeFloatingData   bool
 
 	stopPoints                   *map[string]StopPoint
 	courses                      *map[string][]Course
@@ -790,6 +791,19 @@ func GetEquipmentStatus(start time.Time, end time.Time, now time.Time) string {
 		return "unavailable"
 	}
 
+}
+
+func (d *DataManager) ManageFreeFloatingStatus(activate bool) {
+	d.freeFloatingsMutex.Lock()
+	defer d.freeFloatingsMutex.Unlock()
+
+	d.loadFreeFloatingData = activate
+}
+
+func (d *DataManager) LoadFreeFloatingData() bool {
+	d.freeFloatingsMutex.RLock()
+	defer d.freeFloatingsMutex.RUnlock()
+	return d.loadFreeFloatingData
 }
 
 func (d *DataManager) UpdateFreeFloating(freeFloatings []FreeFloating) {

--- a/type.go
+++ b/type.go
@@ -608,6 +608,7 @@ type DataManager struct {
 	lastFreeFloatingUpdate time.Time
 	freeFloatingsMutex     sync.RWMutex
 	loadFreeFloatingData   bool
+	loadOccupancyData      bool
 
 	stopPoints                   *map[string]StopPoint
 	courses                      *map[string][]Course
@@ -860,6 +861,19 @@ func (d *DataManager) GetFreeFloatings(param *FreeFloatingRequestParameter) (fre
 		sort.Sort(ByDistance(resp))
 	}
 	return resp, nil
+}
+
+func (d *DataManager) ManageVehicleOccupancyStatus(activate bool) {
+	d.vehicleOccupanciesMutex.Lock()
+	defer d.vehicleOccupanciesMutex.Unlock()
+
+	d.loadOccupancyData = activate
+}
+
+func (d *DataManager) LoadOccupancyData() bool {
+	d.vehicleOccupanciesMutex.RLock()
+	defer d.vehicleOccupanciesMutex.RUnlock()
+	return d.loadOccupancyData
 }
 
 func (d *DataManager) InitStopPoint(stopPoints map[string]StopPoint) {


### PR DESCRIPTION
* Use of parameter "**free-floatings-refresh-active**" = (true/false, default value = false) to activate/deactivate loading of flucteo data regularly.
* Activate the loading by .**../status?free_floatings=true**
* When deactivated after the loading of flucteo date (first activation), /free_floatings keep on replying with last loaded data (loaded before last deactivation) 
* Can be verified by supervising **status.last_free_floating_update** value
* Deactivation by **.../status?free_floatings=false**

* Api /status modified:
```{
  "status": "ok",
  "version": "v0.2.2-73-g4decf3c-dirty",
  "last_departure_update": "0001-01-01T00:00:00Z",
  "last_parking_update": "0001-01-01T00:00:00Z",
  "last_equipment_update": "0001-01-01T00:00:00Z",
  "free_floatings": {
    "refresh_active": true,
    "last_update": "2021-03-16T12:34:10.15463435+01:00"
  },
  "vehicle_occupancies": {
    "refresh_active": true,
    "last_update": "2021-03-16T12:30:37.762235883+01:00"
  }
}
```

For more details: https://jira.kisio.org/browse/NAVP-1765