### PR TITLE
[GTFS-RT] Add Google transit like a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "google_transit"]
+	path = google_transit
+	url = git@github.com:google/transit.git


### PR DESCRIPTION
We need now the `gtfs-realtime.proto` for new API. It come in dependency
To keep it without a freezing style, I created a **git submodule**

When we create a submodule, by default the submodule is on the last commit