### PR TITLE
Occupancies Gtfs-RT fo Oditi connector

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -249,7 +249,7 @@ func TestVehicleOccupanciesAPIWithDataFromFile(t *testing.T) {
 	assert.Equal(resp.VehicleOccupancies[0].StopId, "stop_point:0:SP:80:4121")
 	assert.Equal(resp.VehicleOccupancies[0].Direction, 0)
 	assert.Equal(resp.VehicleOccupancies[0].DateTime.Format("20060102T150405"), "20210118T072200")
-	assert.Equal(resp.VehicleOccupancies[0].Occupancy, 11)
+	assert.Equal(resp.VehicleOccupancies[0].Occupancy, 1)
 
 	// Verify /status
 	manager.SetVehiculeOccupanciesContext(vehiculeOccupanciesContext)

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   forseti:
-    image: navitia/forseti:master
+    image: forseti:0.3.0
     ports:
       - target: 8080
         published: 8088

--- a/internal/vehicleoccupancies/occupancy_gtfsRt.go
+++ b/internal/vehicleoccupancies/occupancy_gtfsRt.go
@@ -1,0 +1,64 @@
+package vehicleoccupancies
+
+type Vehicle_OccupancyStatus int
+
+const (
+	// The vehicle is considered empty by most measures, and has few or no
+	// passengers onboard, but is still accepting passengers.
+	VehicleOccupancy_EMPTY Vehicle_OccupancyStatus = 0
+	// The vehicle has a relatively large percentage of seats available.
+	// What percentage of free seats out of the total seats available is to be
+	// considered large enough to fall into this category is determined at the
+	// discretion of the producer.
+	VehicleOccupancy_MANY_SEATS_AVAILABLE Vehicle_OccupancyStatus = 1
+	// The vehicle has a relatively small percentage of seats available.
+	// What percentage of free seats out of the total seats available is to be
+	// considered small enough to fall into this category is determined at the
+	// discretion of the feed producer.
+	VehicleOccupancy_FEW_SEATS_AVAILABLE Vehicle_OccupancyStatus = 2
+	// The vehicle can currently accommodate only standing passengers.
+	VehicleOccupancy_STANDING_ROOM_ONLY Vehicle_OccupancyStatus = 3
+	// The vehicle can currently accommodate only standing passengers
+	// and has limited space for them.
+	VehicleOccupancy_CRUSHED_STANDING_ROOM_ONLY Vehicle_OccupancyStatus = 4
+	// The vehicle is considered full by most measures, but may still be
+	// allowing passengers to board.
+	VehicleOccupancy_FULL Vehicle_OccupancyStatus = 5
+	// The vehicle is not accepting additional passengers.
+	VehicleOccupancy_NOT_ACCEPTING_PASSENGERS Vehicle_OccupancyStatus = 6
+)
+
+var OditiMatchMatrixGtfsRT = [4][2]int{
+	// EMPTY for value equal 0
+	{0, 25},  // MANY_SEATS_AVAILABLE for value between > 0 and 25
+	{25, 50}, // FEW_SEATS_AVAILABLE for value between > 25 and 50
+	{50, 75}, // STANDING_ROOM_ONLY for value between > 50 and 50
+	{75, 99}, // CRUSHED_STANDING_ROOM_ONLY for value between > 75 and 50
+	// FULL for value equal or better than 100
+}
+
+func GetOccupancyStatusForOditi(Oditi_charge int) Vehicle_OccupancyStatus {
+	var s int = 1
+	if Oditi_charge == 0 {
+		return VehicleOccupancy_EMPTY
+	}
+	if Oditi_charge >= 100 {
+		return VehicleOccupancy_FULL
+	}
+
+	for idx, p := range OditiMatchMatrixGtfsRT {
+		if InBetween(Oditi_charge, p[0], p[1]) {
+			s = s + idx
+			break
+		}
+	}
+	return Vehicle_OccupancyStatus(s)
+}
+
+func InBetween(charge, min, max int) bool {
+	if (charge > min) && (charge <= max) {
+		return true
+	} else {
+		return false
+	}
+}

--- a/internal/vehicleoccupancies/vehicleoccupancies.go
+++ b/internal/vehicleoccupancies/vehicleoccupancies.go
@@ -323,7 +323,8 @@ func CreateOccupanciesFromPredictions(context *VehicleOccupanciesContext,
 			stopId := context.GetStopId(predict.StopName, predict.Direction)
 			rs := context.GetRouteSchedule(vehicleJourneyId, stopId, predict.Direction)
 			if rs != nil {
-				vo, err := NewVehicleOccupancy(*rs, utils.CalculateOccupancy(predict.Occupancy))
+				poCalc := utils.CalculateOccupancy(predict.Occupancy)
+				vo, err := NewVehicleOccupancy(*rs, int(GetOccupancyStatusForOditi(poCalc)))
 
 				if err != nil {
 					continue

--- a/internal/vehicleoccupancies/vehicleoccupancies_test.go
+++ b/internal/vehicleoccupancies/vehicleoccupancies_test.go
@@ -272,7 +272,8 @@ func TestDataManagerForVehicleOccupancies(t *testing.T) {
 	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4029") //Copernic : departure StopPoint
 	assert.Equal(vehicleOccupancies[0].Direction, 0)
 	assert.Equal(vehicleOccupancies[0].DateTime, dateTime)
-	assert.Equal(vehicleOccupancies[0].Occupancy, 55)
+	//assert.Equal(vehicleOccupancies[0].Occupancy, 55)
+	assert.Equal(vehicleOccupancies[0].Occupancy, 3)
 
 	// Call Api with another StopId in the paraameter
 	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4142", VehicleJourneyId: "", Date: date}
@@ -287,7 +288,8 @@ func TestDataManagerForVehicleOccupancies(t *testing.T) {
 	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4142") //Pasteur
 	assert.Equal(vehicleOccupancies[0].Direction, 0)
 	assert.Equal(vehicleOccupancies[0].DateTime, dateTime)
-	assert.Equal(vehicleOccupancies[0].Occupancy, 75)
+	//assert.Equal(vehicleOccupancies[0].Occupancy, 75)
+	assert.Equal(vehicleOccupancies[0].Occupancy, 3)
 }
 
 func TestLoadStopPointsFromFile(t *testing.T) {
@@ -390,4 +392,230 @@ func TestLoadPredictionsFromFile(t *testing.T) {
 	assert.Equal(predictions[0].Course, "2774327")
 	assert.Equal(predictions[0].StopName, "Pont de Sevres")
 	assert.Equal(predictions[0].Occupancy, 12)
+}
+
+func TestStatusForVehicleOccupancies(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	location, err := time.LoadLocation("Europe/Paris")
+	require.Nil(err)
+
+	vehiculeOccupanciesContext := &VehicleOccupanciesContext{}
+
+	// Load StopPoints
+	stopPoints := make(map[string]StopPoint)
+	sp, _ := NewStopPoint([]string{"CPC", "Copernic", "0:SP:80:4029", "0"})
+	stopPoints[sp.Name+strconv.Itoa(sp.Direction)] = *sp
+	sp, _ = NewStopPoint([]string{"EXL", "Exelmans", "0:SP:80:4056", "0"})
+	stopPoints[sp.Name+strconv.Itoa(sp.Direction)] = *sp
+	sp, _ = NewStopPoint([]string{"INO", "Inovel Parc Nord", "0:SP:80:4079", "0"})
+	stopPoints[sp.Name+strconv.Itoa(sp.Direction)] = *sp
+	sp, _ = NewStopPoint([]string{"LVS", "Louvois", "0:SP:80:4100", "0"})
+	stopPoints[sp.Name+strconv.Itoa(sp.Direction)] = *sp
+	sp, _ = NewStopPoint([]string{"MDT", "Marcel Dassault", "0:SP:80:4109", "0"})
+	stopPoints[sp.Name+strconv.Itoa(sp.Direction)] = *sp
+	sp, _ = NewStopPoint([]string{"PTR", "Pasteur", "0:SP:80:4142", "0"})
+	stopPoints[sp.Name+strconv.Itoa(sp.Direction)] = *sp
+	vehiculeOccupanciesContext.InitStopPoint(stopPoints)
+	assert.Equal(len(*vehiculeOccupanciesContext.stopPoints), 6)
+
+	// Load Courses
+	courses := make(map[string][]Course)
+	courseLine := []string{"40", "2774327", "1", "05:45:00", "06:06:00", "13",
+		"2020-09-21", "2021-01-18", "2021-01-22 13:27:13.066197+00"}
+	course, err := NewCourse(courseLine, location)
+	require.Nil(err)
+	courses[course.LineCode] = append(courses[course.LineCode], *course)
+
+	courseLine = []string{"40", "2774327", "2", "05:46:00", "06:07:00", "13",
+		"2020-09-21", "2021-01-18", "2021-01-22 13:27:13.066197+00"}
+	course, err = NewCourse(courseLine, location)
+	require.Nil(err)
+	courses[course.LineCode] = append(courses[course.LineCode], *course)
+
+	courseLine = []string{"40", "2774327", "2", "05:47:00", "06:08:00", "13",
+		"2020-09-21", "2021-01-18", "2021-01-22 13:27:13.066197+00"}
+	course, err = NewCourse(courseLine, location)
+	require.Nil(err)
+	courses[course.LineCode] = append(courses[course.LineCode], *course)
+
+	courseLine = []string{"40", "2774327", "2", "05:48:00", "06:09:00", "13",
+		"2020-09-21", "2021-01-18", "2021-01-22 13:27:13.066197+00"}
+	course, err = NewCourse(courseLine, location)
+	require.Nil(err)
+	courses[course.LineCode] = append(courses[course.LineCode], *course)
+
+	courseLine = []string{"40", "2774327", "2", "05:49:00", "06:10:00", "13",
+		"2020-09-21", "2021-01-18", "2021-01-22 13:27:13.066197+00"}
+	course, err = NewCourse(courseLine, location)
+	require.Nil(err)
+	courses[course.LineCode] = append(courses[course.LineCode], *course)
+
+	courseLine = []string{"40", "2774327", "2", "05:50:00", "06:11:00", "13",
+		"2020-09-21", "2021-01-18", "2021-01-22 13:27:13.066197+00"}
+	course, err = NewCourse(courseLine, location)
+	require.Nil(err)
+	courses[course.LineCode] = append(courses[course.LineCode], *course)
+
+	vehiculeOccupanciesContext.InitCourse(courses)
+	assert.Equal(len(*vehiculeOccupanciesContext.courses), 1)
+
+	// Load RouteSchedules
+	routeSchedules := make([]RouteSchedule, 0)
+	rs, err := NewRouteSchedule("40", "stop_point:0:SP:80:4029", "vj_id_one", "20210222T054500", 0, 1, true, location)
+	require.Nil(err)
+	routeSchedules = append(routeSchedules, *rs)
+	rs, err = NewRouteSchedule("40", "stop_point:0:SP:80:4056", "vj_id_one", "20210222T055000", 0, 2, false, location)
+	require.Nil(err)
+	routeSchedules = append(routeSchedules, *rs)
+	rs, err = NewRouteSchedule("40", "stop_point:0:SP:80:4079", "vj_id_one", "20210222T055500", 0, 3, false, location)
+	require.Nil(err)
+	routeSchedules = append(routeSchedules, *rs)
+	rs, err = NewRouteSchedule("40", "stop_point:0:SP:80:4100", "vj_id_one", "20210222T060000", 0, 4, false, location)
+	require.Nil(err)
+	routeSchedules = append(routeSchedules, *rs)
+	rs, err = NewRouteSchedule("40", "stop_point:0:SP:80:4109", "vj_id_one", "20210222T060500", 0, 5, false, location)
+	require.Nil(err)
+	routeSchedules = append(routeSchedules, *rs)
+	rs, err = NewRouteSchedule("40", "stop_point:0:SP:80:4142", "vj_id_one", "20210222T061000", 0, 6, false, location)
+	require.Nil(err)
+	routeSchedules = append(routeSchedules, *rs)
+	vehiculeOccupanciesContext.InitRouteSchedule(routeSchedules)
+	assert.Equal(len(*vehiculeOccupanciesContext.routeSchedules), 6)
+
+	// Load Predictions
+	predictions := make([]Prediction, 0)
+	pn := data.PredictionNode{
+		Line:     "40",
+		Sens:     0,
+		Date:     "2021-02-22T00:00:00",
+		Course:   "2774327",
+		Order:    0,
+		StopName: "Copernic",
+		Charge:   0}
+	p := NewPrediction(pn, location)
+	require.NotNil(p)
+	predictions = append(predictions, *p)
+	pn = data.PredictionNode{
+		Line:     "40",
+		Sens:     0,
+		Date:     "2021-02-22T00:00:00",
+		Course:   "2774327",
+		Order:    1,
+		StopName: "Exelmans",
+		Charge:   6}
+	p = NewPrediction(pn, location)
+	require.NotNil(p)
+	predictions = append(predictions, *p)
+	pn = data.PredictionNode{
+		Line:     "40",
+		Sens:     0,
+		Date:     "2021-02-22T00:00:00",
+		Course:   "2774327",
+		Order:    1,
+		StopName: "Inovel Parc Nord",
+		Charge:   34}
+	p = NewPrediction(pn, location)
+	require.NotNil(p)
+	predictions = append(predictions, *p)
+	pn = data.PredictionNode{
+		Line:     "40",
+		Sens:     0,
+		Date:     "2021-02-22T00:00:00",
+		Course:   "2774327",
+		Order:    1,
+		StopName: "Louvois",
+		Charge:   60}
+	p = NewPrediction(pn, location)
+	require.NotNil(p)
+	predictions = append(predictions, *p)
+	pn = data.PredictionNode{
+		Line:     "40",
+		Sens:     0,
+		Date:     "2021-02-22T00:00:00",
+		Course:   "2774327",
+		Order:    1,
+		StopName: "Marcel Dassault",
+		Charge:   76}
+	p = NewPrediction(pn, location)
+	require.NotNil(p)
+	predictions = append(predictions, *p)
+	pn = data.PredictionNode{
+		Line:     "40",
+		Sens:     0,
+		Date:     "2021-02-22T00:00:00",
+		Course:   "2774327",
+		Order:    1,
+		StopName: "Pasteur",
+		Charge:   100}
+	p = NewPrediction(pn, location)
+	require.NotNil(p)
+	predictions = append(predictions, *p)
+	assert.Equal(len(predictions), 6)
+
+	// Create VehicleOccupancies from existing data
+	occupanciesWithCharge := CreateOccupanciesFromPredictions(vehiculeOccupanciesContext, predictions)
+	assert.Equal(len(occupanciesWithCharge), 6)
+	vehiculeOccupanciesContext.UpdateVehicleOccupancies(occupanciesWithCharge)
+	assert.Equal(len(*vehiculeOccupanciesContext.vehicleOccupancies), 6)
+	date, err := time.ParseInLocation("2006-01-02", "2021-02-22", location)
+	require.Nil(err)
+	param := VehicleOccupancyRequestParameter{StopId: "", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err := vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 6)
+
+	// Call Api with occupancy EMPTY
+	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4029", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err = vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 1)
+	// Verify occupancy status
+	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4029") //Copernic : departure StopPoint
+	assert.Equal(vehicleOccupancies[0].Occupancy, 0)
+
+	// Call Api with occupancy MANY_SEATS_AVAILABLE
+	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4056", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err = vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 1)
+	// Verify occupancy status
+	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4056") //Pasteur
+	assert.Equal(vehicleOccupancies[0].Occupancy, 1)
+
+	// Call Api with occupancy FEW_SEATS_AVAILABLE
+	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4079", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err = vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 1)
+	// Verify occupancy status
+	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4079") //Pasteur
+	assert.Equal(vehicleOccupancies[0].Occupancy, 2)
+
+	// Call Api with occupancy STANDING_ROOM_ONLY
+	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4100", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err = vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 1)
+	// Verify occupancy status
+	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4100") //Pasteur
+	assert.Equal(vehicleOccupancies[0].Occupancy, 3)
+
+	// Call Api with occupancy CRUSHED_STANDING_ROOM_ONLY
+	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4109", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err = vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 1)
+	// Verify occupancy status
+	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4109") //Pasteur
+	assert.Equal(vehicleOccupancies[0].Occupancy, 4)
+
+	// Call Api with occupancy FULL
+	param = VehicleOccupancyRequestParameter{StopId: "stop_point:0:SP:80:4142", VehicleJourneyId: "", Date: date}
+	vehicleOccupancies, err = vehiculeOccupanciesContext.GetVehicleOccupancies(&param)
+	require.Nil(err)
+	assert.Equal(len(vehicleOccupancies), 1)
+	// Verify occupancy status
+	assert.Equal(vehicleOccupancies[0].StopId, "stop_point:0:SP:80:4142") //Pasteur
+	assert.Equal(vehicleOccupancies[0].Occupancy, 5)
 }


### PR DESCRIPTION
Adaptation of the Oditi connector to report occupancy levels in GTFS-RT format.
I added the tests to check the full range

| Description | GTFS-RT value | ODITI value |
| --- | --- | --- |
| EMPTY | 0 | 0% |
|MANY_SEATS_AVAILABLE | 1 | 0-25%
|FEW_SEATS_AVAILABLE | 2 | 25-50%
|STANDING_ROOM_ONLY | 3 | 50-75%
|CRUSHED_STANDING_ROOM_ONLY | 4 | 75-99%
|FULL | 5 | 100% et +
