### PR TITLE
[Prometheus] Feat: add swarm_monitoring network

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
         - traefik.redirectorservice.frontend.entryPoints=http
     networks:
       - lb-common
+      - monitor-local
     logging:
       driver: "fluentd"
       options:
@@ -59,4 +60,7 @@ services:
 networks:
   lb-common:
     name: lb-common
+    external: true
+  monitor-local:
+    name: monitor-local
     external: true


### PR DESCRIPTION
Based on what was asked here : 
> 4. Pour les graphes, écoute, on est prêt. Si tu appels http://forseti-cus-oditi.canaltp.prod/metrics ou http://forseti-int-oditi.canaltp.prod/metrics tu vas voir qu'on te remonte bien les métriques prometheus.
T'as plus qu'à récupérer ça dans ton serveur prometheus/Graphana et roulez jeunesse 

Lets try to implement it, the same way we did for asgard. 